### PR TITLE
tldr: Use `main` branch instead of `master`

### DIFF
--- a/ttldr
+++ b/ttldr
@@ -120,7 +120,7 @@ case x${1-} in x|x-*)
 esac
 cmd=$1; shift
 
-base=https://raw.githubusercontent.com/tldr-pages/tldr/master/pages
+base=https://raw.githubusercontent.com/tldr-pages/tldr/main/pages
 for plat in common linux osx windows sunos; do  # from most to least pages
     for lng in ${TT_LANG-} ''; do
         curl -sf "$base${lng:+.$lng}/$plat/$cmd.md" | tldr-fmt -e1 "$@" && exit


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).